### PR TITLE
fix(starboard): prevent duplicate starboard messages on concurrent reactions

### DIFF
--- a/src/commands/pseudo/starboard.ts
+++ b/src/commands/pseudo/starboard.ts
@@ -22,6 +22,7 @@ import {
     User,
 } from 'discord.js';
 import { CommandLoader } from '..';
+import { QueryFailedError } from 'typeorm';
 
 /*
  * Starboard system for highlighting popular messages in a dedicated channel based on user reactions.
@@ -93,8 +94,11 @@ export default class StarboardCommand extends CustomizableCommand {
         const reaction_emoji = reaction.emoji.id ? reaction.emoji.toString() : reaction.emoji.name;
         if (reaction_emoji !== starboard.emoji) return;
 
+        // Ignore reactions on messages already in the starboard channel
+        if (message.channel.id === starboard.channel_id.toString()) return;
+
         // Fetch or create the starboard message record in the database
-        const guild = await this.db.getGuild(BigInt(message.guild.id));
+        const guild = await this.db.getGuild(BigInt(message.guild!.id));
         let starboard_msg = await this.db.findOne(StarboardLogs, {
             where: { source_message: { message_id: BigInt(message.id) } },
         });
@@ -104,12 +108,9 @@ export default class StarboardCommand extends CustomizableCommand {
         // Check if users are allowed to star their own messages and if the reactor is the message author
         if (is_add && !starboard.allow_self_star && message.author?.id === user.id) return;
 
-        // Ignore reactions on messages already in the starboard channel
-        if (message.channel.id === starboard.channel_id.toString()) return;
-
         // Fetch the starboard channel and check if it's sendable
         const starboard_channel = await BotClient.client.guilds
-            .fetch(message.guild.id)
+            .fetch(message.guild!.id)
             .then((g) => g.channels.fetch(starboard.channel_id!.toString()));
         if (!starboard_channel?.isSendable()) return;
 
@@ -118,16 +119,24 @@ export default class StarboardCommand extends CustomizableCommand {
         if (!starboard_msg) {
             if (reaction_count < starboard.threshold) return;
             const chan = await RegisterFact<Channel>(message.channel, undefined);
-            const user = await RegisterFact<User>(message.author!, undefined);
+            const author = await RegisterFact<User>(message.author!, undefined);
             let msg = await this.db.findOne(Messages, { where: { message_id: BigInt(message.id) } });
             if (!msg) {
                 msg = new Messages();
                 msg.timestamp = new Date(message.createdTimestamp);
                 msg.message_id = BigInt(message.id);
                 msg.from_channel = chan;
-                msg.from_user = user;
+                msg.from_user = author;
                 msg.from_guild = guild!;
-                await this.db.save(Messages, msg);
+                try {
+                    await this.db.save(Messages, msg);
+                } catch (e) {
+                    if (e instanceof QueryFailedError && (e as any).driverError?.code === '23505') {
+                        msg = (await this.db.findOne(Messages, { where: { message_id: BigInt(message.id) } }))!;
+                    } else {
+                        throw e;
+                    }
+                }
             }
             starboard_msg = new StarboardLogs();
             starboard_msg.star_count = reaction_count;
@@ -135,7 +144,19 @@ export default class StarboardCommand extends CustomizableCommand {
             starboard_msg.from_user = await RegisterFact<User>(message.author!, undefined);
             starboard_msg.from_channel = await RegisterFact<Channel>(message.channel, undefined);
             starboard_msg.from_guild = guild!;
-            await this.db.save(StarboardLogs, starboard_msg);
+            try {
+                await this.db.save(StarboardLogs, starboard_msg);
+            } catch (e) {
+                if (e instanceof QueryFailedError && (e as any).driverError?.code === '23505') {
+                    starboard_msg = (await this.db.findOne(StarboardLogs, {
+                        where: { source_message: { message_id: BigInt(message.id) } },
+                    }))!;
+                    starboard_msg.star_count = reaction_count;
+                    await this.db.save(StarboardLogs, starboard_msg);
+                } else {
+                    throw e;
+                }
+            }
         } else {
             starboard_msg.star_count = reaction_count;
             await this.db.save(StarboardLogs, starboard_msg);

--- a/src/types/database/entities/messages.ts
+++ b/src/types/database/entities/messages.ts
@@ -14,7 +14,7 @@ export class Messages {
     @Column({ type: 'boolean', nullable: false, default: false })
     message_is_edited!: boolean;
 
-    @Column({ type: 'bigint', nullable: false })
+    @Column({ type: 'bigint', nullable: false, unique: true })
     message_id!: bigint;
 
     @Column({ type: 'bigint', nullable: true, default: null })

--- a/src/types/database/entities/starboard.ts
+++ b/src/types/database/entities/starboard.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 import { Channels } from './channels';
 import { Guilds } from './guilds';
 import { Messages } from './messages';
@@ -39,6 +39,7 @@ export class Starboard {
     timestamp!: Date;
 }
 
+@Unique(['source_message'])
 @Entity()
 export class StarboardLogs {
     @PrimaryGeneratedColumn({ type: 'smallint' })

--- a/src/types/database/migrations/1776534578000-add-unique-constraints-starboard.ts
+++ b/src/types/database/migrations/1776534578000-add-unique-constraints-starboard.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUniqueConstraintsStarboard1776534578000 implements MigrationInterface {
+    name = 'AddUniqueConstraintsStarboard1776534578000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Deduplicate messages: keep the earliest row per message_id
+        await queryRunner.query(`
+            DELETE FROM messages m
+            USING messages m2
+            WHERE m.message_id = m2.message_id
+              AND m.id > m2.id
+        `);
+
+        // Deduplicate starboard_logs: keep the row with the highest star_count per source_message
+        await queryRunner.query(`
+            DELETE FROM starboard_logs sl
+            USING starboard_logs sl2
+            WHERE sl.message_id = sl2.message_id
+              AND sl.id < sl2.id
+        `);
+
+        // Add unique constraints
+        await queryRunner.query(`ALTER TABLE messages ADD CONSTRAINT UQ_messages_message_id UNIQUE (message_id)`);
+        await queryRunner.query(
+            `ALTER TABLE starboard_logs ADD CONSTRAINT UQ_starboard_logs_message_id UNIQUE (message_id)`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE starboard_logs DROP CONSTRAINT UQ_starboard_logs_message_id`);
+        await queryRunner.query(`ALTER TABLE messages DROP CONSTRAINT UQ_messages_message_id`);
+    }
+}


### PR DESCRIPTION
Added database-level unique constraints to prevent concurrent events from creating duplicate entries.

- Unique(['source_message']) on StarboardLogs — one starboard entry per source message
- unique: true on Messages.message_id — one record per Discord message
- Catch PostgreSQL unique violations (23505) and re-query existing rows
- Migration deduplicates existing data before adding constraints